### PR TITLE
version 0.0.108

### DIFF
--- a/channel_app/app/order/service.py
+++ b/channel_app/app/order/service.py
@@ -132,11 +132,16 @@ class OrderService(object):
 
         return order
 
-    def update_orders(self, is_sync=True, is_success_log=True):
+    def update_orders(self, is_sync=True, is_success_log=True,
+                      add_order_items=False):
         with OmnitronIntegration(
                 content_type=ContentType.order.value) as omnitron_integration:
             orders = omnitron_integration.do_action(key='get_orders')
             orders: List[Order]
+
+            if add_order_items:
+                orders = orders and omnitron_integration.do_action(
+                    key='get_order_items_with_order', objects=orders)
 
             if not orders:
                 return

--- a/channel_app/app/product/service.py
+++ b/channel_app/app/product/service.py
@@ -198,8 +198,8 @@ class ProductService(object):
 
             for batch_request in batch_request_data:
                 response_data, report, data = ChannelIntegration().do_action(
-                    key='check_deleted_products',
-                    objects=batch_request)
+                    key='check_deleted_products', objects=batch_request,
+                    batch_request=batch_request)
 
                 # tips
                 response_data: List[ProductBatchRequestResponseDto]
@@ -214,7 +214,7 @@ class ProductService(object):
                     omnitron_integration.batch_request = batch_request
                     omnitron_integration.do_action(
                         key='process_delete_product_batch_requests',
-                        objects=batch_request)
+                        objects=response_data)
 
     def get_product_batch_requests(self, is_success_log=True):
         with OmnitronIntegration(create_batch=False) as omnitron_integration:
@@ -228,7 +228,8 @@ class ProductService(object):
 
             for batch_request in batch_request_data:
                 response_data, report, data = ChannelIntegration().do_action(
-                    key='check_products', objects=batch_request)
+                    key='check_products', objects=batch_request,
+                    batch_request=batch_request)
 
                 # tips
                 response_data: List[ProductBatchRequestResponseDto]

--- a/channel_app/omnitron/commands/orders/orders.py
+++ b/channel_app/omnitron/commands/orders/orders.py
@@ -62,6 +62,28 @@ class GetOrderItems(OmnitronCommandInterface):
                                    objects=order_items)
         return order_items
 
+    def get_order_items(self, order):
+        params = {"order": order.pk}
+        endpoint = self.endpoint(channel_id=self.integration.channel_id)
+        order_items = endpoint.list(params=params)
+        for item in endpoint.iterator:
+            if not item:
+                break
+            order_items.extend(item)
+        return order_items
+
+
+class GetOrderItemsWithOrder(GetOrderItems):
+    endpoint = ChannelOrderItemEndpoint
+
+    def get_data(self):
+        orders = self.objects
+        for order in orders:
+            order_items = self.get_order_items(order)
+            order.orderitem_set = order_items
+
+        return orders
+
 
 class ProcessOrderBatchRequests(OmnitronCommandInterface, ProcessBatchRequests):
     """

--- a/channel_app/omnitron/integration.py
+++ b/channel_app/omnitron/integration.py
@@ -21,7 +21,9 @@ from channel_app.omnitron.commands.orders.orders import (
     GetOrders,
     ProcessOrderBatchRequests,
     CreateOrderCancel,
-    GetCancellationRequest)
+    GetCancellationRequest,
+    GetOrderItems,
+    GetOrderItemsWithOrder)
 from channel_app.omnitron.commands.product_images import (
     GetUpdatedProductImages, GetInsertedProductImages,
     ProcessImageBatchRequests)
@@ -101,6 +103,8 @@ class OmnitronIntegration(BaseIntegration):
         "get_cargo_company": GetCargoCompany,
         "create_order": CreateOrders,
         "get_orders": GetOrders,
+        "get_order_items": GetOrderItems,
+        "get_order_items_with_order": GetOrderItemsWithOrder,
         "create_order_shipping_info": CreateOrderShippingInfo,
         "create_or_update_category_tree_and_nodes": CreateOrUpdateCategoryTreeAndNodes,
         "create_or_update_category_attributes": CreateOrUpdateCategoryAttributes,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as f:
 
 setup(
     name="channel_app",
-    version="0.0.107",
+    version="0.0.108",
     packages=find_packages(),
     url="https://github.com/akinon/channel_app",
     description="Channel app for Sales Channels",


### PR DESCRIPTION
- Add GetOrderItems to OmnitronIntegration.actions
- Add GetOrderItemsWithOrder Command to add orderitem_set to order
- Add batch_request to check_deleted_products and check_products commands
- Fix process_delete_product_batch_requests by adding response data to objects


Added get_order_items method missing from GetOrderItems Command in Commit.
Order_items were added with monkey_patching into orders taken with GetOrders in Commit.
In Commit, Error Reports were not generated in Check commands because batch_requests were not added. Added batch_requests.
Added response_data in process_delete_product_batch_requests in ommit.
