### PR TITLE
Add endpoint iterator to CreateOrders.get_products method

### DIFF
--- a/channel_app/omnitron/commands/orders/orders.py
+++ b/channel_app/omnitron/commands/orders/orders.py
@@ -309,9 +309,16 @@ class CreateOrders(OmnitronCommandInterface):
         for chunk in split_list(product_remote_ids, self.CHUNK_SIZE):
             params = {"channel": self.integration.channel_id,
                       "content_type_name": ContentType.product.value,
-                      "remote_id__in": ",".join(chunk)}
+                      "remote_id__in": ",".join(chunk),
+                      "sort": "id"}
             ia = endpoint.list(params=params)
+            for item in endpoint.iterator:
+                if not item:
+                    break
+                ia.extend(item)
+
             product_integration_actions.extend(ia)
+
         return {ia.remote_id: ia.object_id for ia in
                 product_integration_actions}
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md") as f:
 
 setup(
     name="channel_app",
-    version="0.0.109",
+    version="0.0.110",
     packages=find_packages(),
     url="https://github.com/akinon/channel_app",
     description="Channel app for Sales Channels",


### PR DESCRIPTION
channel_app.omnitron.commands.orders.orders.CreateOrders.get_products

Methodunda product’lar alınırken iterator kullanılmadığı için sadece ilk 10 ürün alınmaktadır. Bu yüzden bir Order’da 10’dan fazla OrderItem objesi bulunduğu durumda bu Order Omnitron tarafında oluşturulamamaktadır.